### PR TITLE
Added AL2 license alias (used by WildFly Swarm)

### DIFF
--- a/src/main/resources/rh-license-names.json
+++ b/src/main/resources/rh-license-names.json
@@ -23,7 +23,8 @@
       "Apache License 2.0",
       "ASL 2.0",
       "ASL, version 2",
-      "Apache-2.0"
+      "Apache-2.0",
+      "AL2"
     ],
     "urlAliases": [
       "http://www.apache.org/licenses/LICENSE-2.0",


### PR DESCRIPTION
Swarm, which is licensed under Apache Software License 2.0, uses AL2 in the poms as the license name.
The purpose of this PR is to assure proper handling of Swarm's artifacts.