### PR TITLE
Continue processing on invalid pom

### DIFF
--- a/src/main/java/me/snowdrop/licenses/LicenseSummaryFactory.java
+++ b/src/main/java/me/snowdrop/licenses/LicenseSummaryFactory.java
@@ -16,14 +16,15 @@
 
 package me.snowdrop.licenses;
 
+import me.snowdrop.licenses.sanitiser.LicenseSanitiser;
+import me.snowdrop.licenses.xml.DependencyElement;
+import me.snowdrop.licenses.xml.LicenseSummary;
+import org.apache.maven.artifact.Artifact;
+
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.maven.project.MavenProject;
-import me.snowdrop.licenses.sanitiser.LicenseSanitiser;
-import me.snowdrop.licenses.xml.DependencyElement;
-import me.snowdrop.licenses.xml.LicenseSummary;
 
 /**
  * Class responsible for retrieving licenses information based on a provided GAV.
@@ -38,7 +39,7 @@ public class LicenseSummaryFactory {
         this.licenseSanitiser = licenseSanitiser;
     }
 
-    public LicenseSummary getLicenseSummary(Collection<MavenProject> mavenProjects) {
+    public LicenseSummary getLicenseSummary(Collection<Artifact> mavenProjects) {
         List<DependencyElement> dependencyElements =
                 mavenProjects.parallelStream()
                         .map(DependencyElement::new)

--- a/src/main/java/me/snowdrop/licenses/LicensesFileManager.java
+++ b/src/main/java/me/snowdrop/licenses/LicensesFileManager.java
@@ -16,10 +16,10 @@
 
 package me.snowdrop.licenses;
 
-import org.apache.commons.io.FileUtils;
 import me.snowdrop.licenses.xml.DependencyElement;
 import me.snowdrop.licenses.xml.LicenseElement;
 import me.snowdrop.licenses.xml.LicenseSummary;
+import org.apache.commons.io.FileUtils;
 import org.jtwig.JtwigModel;
 import org.jtwig.JtwigTemplate;
 
@@ -44,6 +44,8 @@ import java.util.stream.Collectors;
 public class LicensesFileManager {
 
     private final Logger logger = Logger.getLogger(LicensesFileManager.class.getSimpleName());
+    private static final int DOWNLOAD_TIMEOUT = 60_000;
+    private static final int CONNECTION_TIMEOUT = 20_000;
 
     /**
      * Create a licenses.xml file.
@@ -103,7 +105,7 @@ public class LicensesFileManager {
             File file = new File(directoryPath, fileName);
             if (!file.exists()) {
                 URL url = new URL(license.getTextUrl());
-                FileUtils.copyURLToFile(url, file);
+                FileUtils.copyURLToFile(url, file, CONNECTION_TIMEOUT, DOWNLOAD_TIMEOUT);
             }
             return Optional.of(new AbstractMap.SimpleEntry<>(license.getName(), fileName));
         } catch (IOException e) {

--- a/src/main/java/me/snowdrop/licenses/sanitiser/AliasLicenseSanitiser.java
+++ b/src/main/java/me/snowdrop/licenses/sanitiser/AliasLicenseSanitiser.java
@@ -52,6 +52,8 @@ public class AliasLicenseSanitiser implements LicenseSanitiser {
                 RedHatLicense redHatLicense = redHatLicenseOptional.get();
                 licenseElement.setName(redHatLicense.getName());
                 licenseElement.setUrl(redHatLicense.getUrl());
+                String textUrl = redHatLicense.getTextUrl();
+                if (textUrl != null) licenseElement.setTextUrl(textUrl);
             } else {
                 shouldCallNext = true;
             }

--- a/src/main/java/me/snowdrop/licenses/sanitiser/MavenSanitiser.java
+++ b/src/main/java/me/snowdrop/licenses/sanitiser/MavenSanitiser.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.snowdrop.licenses.sanitiser;
+
+import me.snowdrop.licenses.maven.MavenProjectFactory;
+import me.snowdrop.licenses.xml.DependencyElement;
+import me.snowdrop.licenses.xml.LicenseElement;
+import org.apache.maven.project.MavenProject;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * @author Michal Szynkiewicz, michal.l.szynkiewicz@gmail.com
+ * <br>
+ * Date: 1/25/18
+ */
+public class MavenSanitiser implements LicenseSanitiser {
+
+    private final MavenProjectFactory mavenProjectFactory;
+    private final LicenseSanitiser next;
+
+    public MavenSanitiser(MavenProjectFactory mavenProjectFactory, LicenseSanitiser next) {
+        this.mavenProjectFactory = mavenProjectFactory;
+        this.next = next;
+    }
+    
+    @Override
+    public DependencyElement fix(DependencyElement dependencyElement) {
+        DependencyElement result;
+        Set<LicenseElement> licenses = dependencyElement.getLicenses();
+        if (licenses == null || licenses.isEmpty()) {
+            Optional<MavenProject> mavenProject =
+                    mavenProjectFactory.getMavenProject(dependencyElement.getArtifact(), false);
+            Set<LicenseElement> licensesFromPom = mavenProject
+                    .orElseThrow(() ->
+                            new RuntimeException("Unable to find licenses neither through maven or previous sanitisers for " + dependencyElement))
+                    .getLicenses()
+                    .stream()
+                    .map(LicenseElement::new)
+                    .collect(Collectors.toSet());
+
+            result = new DependencyElement(dependencyElement, licensesFromPom);
+        } else {
+            result = dependencyElement;
+        }
+
+        return next.fix(result);
+    }
+}

--- a/src/main/java/me/snowdrop/licenses/sanitiser/RedHatLicense.java
+++ b/src/main/java/me/snowdrop/licenses/sanitiser/RedHatLicense.java
@@ -32,6 +32,8 @@ public class RedHatLicense {
 
     private String url;
 
+    private String textUrl;
+
     private Set<String> aliases;
 
     private Set<String> urlAliases;
@@ -39,6 +41,7 @@ public class RedHatLicense {
     public RedHatLicense(JsonObject jsonObject) {
         this.name = jsonObject.getString("name");
         this.url = jsonObject.getString("url");
+        this.textUrl = jsonObject.getString("textUrl", null);
         this.aliases = jsonObject.getJsonArray("aliases")
                 .getValuesAs(JsonString.class)
                 .stream()
@@ -72,6 +75,10 @@ public class RedHatLicense {
     }
 
     public LicenseElement toLicenseElement() {
-        return new LicenseElement(name, url);
+        return new LicenseElement(name, url, textUrl);
+    }
+
+    public String getTextUrl() {
+        return textUrl;
     }
 }

--- a/src/main/java/me/snowdrop/licenses/xml/DependencyElement.java
+++ b/src/main/java/me/snowdrop/licenses/xml/DependencyElement.java
@@ -16,17 +16,19 @@
 
 package me.snowdrop.licenses.xml;
 
+import org.apache.maven.artifact.Artifact;
+
+import javax.json.JsonObject;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.XmlType;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.json.JsonObject;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElementWrapper;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
-import org.apache.maven.project.MavenProject;
 
 /**
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
@@ -42,18 +44,20 @@ public class DependencyElement {
     private String version;
 
     private Set<LicenseElement> licenses;
+    
+    private Artifact artifact;
 
     public DependencyElement() {
     }
 
-    public DependencyElement(MavenProject mavenProject) {
-        this.groupId = mavenProject.getGroupId();
-        this.artifactId = mavenProject.getArtifactId();
-        this.version = mavenProject.getVersion();
-        this.licenses = mavenProject.getLicenses()
-                .stream()
-                .map(LicenseElement::new)
-                .collect(Collectors.toSet());
+
+
+    public DependencyElement(Artifact artifact) {
+        this.groupId = artifact.getGroupId();
+        this.artifactId = artifact.getArtifactId();
+        this.version = artifact.getVersion();
+
+        this.artifact = artifact;
     }
 
     public DependencyElement(DependencyElement dependencyElement) {
@@ -168,5 +172,10 @@ public class DependencyElement {
 
     public String toGavString() {
         return String.format("%s:%s:%s", groupId, artifactId, version);
+    }
+
+    @XmlTransient
+    public Artifact getArtifact() {
+        return artifact;
     }
 }

--- a/src/main/resources/rh-license-names.json
+++ b/src/main/resources/rh-license-names.json
@@ -10,7 +10,7 @@
     ]
   },
   {
-    "name": "Apache Software License, Version 2.0",
+    "name": "Apache License 2.0",
     "url": "http://www.apache.org/licenses/LICENSE-2.0",
     "aliases": [
       "Apache Software License, Version 2.0",
@@ -33,10 +33,13 @@
     ]
   },
   {
-    "name": "GNU Lesser General Public License, Version 2.1",
-    "url": "http://repository.jboss.org/licenses/lgpl-2.1.txt",
+    "name": "GNU Lesser General Public License v2.1 only",
+    "textUrl": "http://repository.jboss.org/licenses/lgpl-2.1.txt",
+    "url": "http://www.gnu.org/licenses/old-licenses/lgpl-2.1.html",
     "aliases": [
+      "GNU Lesser General Public License (LGPL), Version 2.1",
       "GNU Lesser General Public License, Version 2.1",
+      "lgpl",
       "LGPL 2.1",
       "LGPL, version 2.1"
     ],
@@ -50,7 +53,7 @@
   },
   {
     "name": "GNU Lesser General Public License, Version 3",
-    "url": "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+    "url": "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
     "aliases": [
       "GNU Lesser General Public License, Version 3",
       "The GNU Lesser General Public License, version 3"
@@ -106,7 +109,7 @@
   },
   {
     "name": "MIT License",
-    "url": "https://opensource.org/licenses/MIT",
+    "url": "http://www.opensource.org/licenses/MIT",
     "aliases": [
       "MIT License",
       "The MIT License"
@@ -149,7 +152,8 @@
     "url": "https://netbeans.org/cddl-gplv2.html",
     "aliases": [
       "Common Development and Distribution License (CDDL) and GNU Public License v.2 w/Classpath Exception",
-      "CDDL + GPLv2 with classpath exception"
+      "CDDL + GPLv2 with classpath exception",
+      "CDDL or GPLv2 with exceptions"
     ],
     "urlAliases": [
       "https://netbeans.org/cddl-gplv2.html",

--- a/src/test/java/me/snowdrop/licenses/ExternalLicensesTest.java
+++ b/src/test/java/me/snowdrop/licenses/ExternalLicensesTest.java
@@ -5,15 +5,16 @@ import me.snowdrop.licenses.properties.GeneratorProperties;
 import me.snowdrop.licenses.xml.DependencyElement;
 import me.snowdrop.licenses.xml.LicenseElement;
 import me.snowdrop.licenses.xml.LicenseSummary;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.artifact.DefaultArtifact;
+import org.apache.maven.artifact.handler.DefaultArtifactHandler;
 import org.apache.maven.model.License;
-import org.apache.maven.project.MavenProject;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
@@ -57,7 +58,10 @@ public class ExternalLicensesTest {
         GeneratorProperties properties = mock(GeneratorProperties.class);
 
         when(properties.getLicenseServiceUrl()).thenReturn(Optional.of(licenseServiceUrl));
-        summaryFactory = LicensesGenerator.createLicenseSummaryFactory(properties);
+
+        LicensesGenerator generator = new LicensesGenerator(properties);
+
+        summaryFactory = generator.createLicenseSummaryFactory();
     }
 
     @AfterClass
@@ -103,24 +107,17 @@ public class ExternalLicensesTest {
     }
 
     private Set<LicenseElement> getLicensesForGav(String gav) throws MavenProjectFactoryException {
-        LicenseSummary licenseSummary = summaryFactory.getLicenseSummary(singleton(mavenProject(gav)));
+        LicenseSummary licenseSummary = summaryFactory.getLicenseSummary(singleton(artifact(gav)));
         assertThat(licenseSummary.getDependencies()).hasSize(1);
 
         DependencyElement element = licenseSummary.getDependencies().get(0);
         return element.getLicenses();
     }
 
-    private MavenProject mavenProject(String gavAsString) throws MavenProjectFactoryException {
+    private Artifact artifact(String gavAsString) throws MavenProjectFactoryException {
         String gav[] = gavAsString.split(":");
-        MavenProject mavenProject = new MavenProject();
-        mavenProject.setGroupId(gav[0]);
-        mavenProject.setArtifactId(gav[1]);
-        mavenProject.setVersion(gav[2]);
-
-        License license = mavenLicense(ECLIPSE_LICENSE_NAME, ECLIPSE_LICENSE_LINK);
-
-        mavenProject.setLicenses(Collections.singletonList(license));
-        return mavenProject;
+        return new DefaultArtifact(gav[0], gav[1], gav[2],
+                "compile", "jar", "", new DefaultArtifactHandler());
     }
 
     private License mavenLicense(String name, String url) {

--- a/src/test/java/me/snowdrop/licenses/LicenseSummaryFactoryTest.java
+++ b/src/test/java/me/snowdrop/licenses/LicenseSummaryFactoryTest.java
@@ -1,17 +1,12 @@
 package me.snowdrop.licenses;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import java.util.Collection;
-import java.util.Collections;
-
+import me.snowdrop.licenses.maven.MavenProjectFactory;
 import me.snowdrop.licenses.sanitiser.LicenseSanitiser;
+import me.snowdrop.licenses.sanitiser.MavenSanitiser;
 import me.snowdrop.licenses.xml.DependencyElement;
 import me.snowdrop.licenses.xml.LicenseElement;
 import me.snowdrop.licenses.xml.LicenseSummary;
+import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.License;
 import org.apache.maven.project.MavenProject;
 import org.junit.Before;
@@ -19,40 +14,62 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 /**
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
 public class LicenseSummaryFactoryTest {
 
     @Mock
+    private Artifact mockArtifact;
+    @Mock
     private MavenProject mockMavenProject;
 
     @Mock
     private License mockLicense;
-
     @Mock
     private LicenseSanitiser mockLicenseSanitiser;
+    @Mock
+    private MavenProjectFactory projectFactoryMock;
 
     private LicenseSummaryFactory licenseSummaryFactory;
+    private MavenSanitiser mavenSanitiser;
 
     @Before
     public void before() {
         MockitoAnnotations.initMocks(this);
         when(mockLicenseSanitiser.fix(any())).then(a -> a.getArgument(0));
 
-        licenseSummaryFactory = new LicenseSummaryFactory(mockLicenseSanitiser);
+        mavenSanitiser = new MavenSanitiser(projectFactoryMock, mockLicenseSanitiser);
+        licenseSummaryFactory = new LicenseSummaryFactory(mavenSanitiser);
     }
 
     @Test
     public void shouldGetLicenseSummary() {
+        when(mockArtifact.getGroupId()).thenReturn("testGroupId");
+        when(mockArtifact.getArtifactId()).thenReturn("testArtifactId");
+        when(mockArtifact.getVersion()).thenReturn("testVersion");
+
         when(mockMavenProject.getGroupId()).thenReturn("testGroupId");
         when(mockMavenProject.getArtifactId()).thenReturn("testArtifactId");
         when(mockMavenProject.getVersion()).thenReturn("testVersion");
         when(mockMavenProject.getLicenses()).thenReturn(Collections.singletonList(mockLicense));
+
+        when(projectFactoryMock.getMavenProject(any(), eq(false))).thenReturn(Optional.of(mockMavenProject));
+
         when(mockLicense.getName()).thenReturn("testLicenseName");
         when(mockLicense.getUrl()).thenReturn("testLicenseUrl");
 
-        Collection<MavenProject> mavenProjects = Collections.singleton(mockMavenProject);
+        Collection<Artifact> mavenProjects = Collections.singleton(mockArtifact);
         LicenseSummary licenseSummary = licenseSummaryFactory.getLicenseSummary(mavenProjects);
 
         assertThat(licenseSummary).isNotNull();

--- a/src/test/java/me/snowdrop/licenses/sanitiser/AliasLicenseSanitiserTest.java
+++ b/src/test/java/me/snowdrop/licenses/sanitiser/AliasLicenseSanitiserTest.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -107,7 +108,7 @@ public class AliasLicenseSanitiserTest {
     public void shouldFixTwoLicenses() {
         List<LicenseElement> licenseElements = Arrays.asList(
                 new LicenseElement("Test License Alias", "http://test-license-alias.com", "http://text-url.com"),
-                new LicenseElement("Test License Alias 2", "http://test-license-alias-2.com","http://text-url.com")
+                new LicenseElement("Test License Alias 2", "http://test-license-alias-2.com", "http://text-url.com")
         );
 
         DependencyElement dependencyElement = new DependencyElement("", "", "", new HashSet<>(licenseElements));
@@ -157,6 +158,25 @@ public class AliasLicenseSanitiserTest {
         assertThat(fixedDependencyElement).isNull();
 
         verify(mockLicenseSanitiser).fix(dependencyElement);
+    }
+
+    @Test
+    public void shouldUseTextUrl() {
+        Set<LicenseElement> licenseElements = Collections.singleton(
+                new LicenseElement("Test License Name 3", "wrong-url")
+        );
+
+        DependencyElement dependencyElement = new DependencyElement("", "", "", licenseElements);
+        DependencyElement fixedDependencyElement = aliasLicenseSanitiser.fix(dependencyElement);
+
+        assertThat(fixedDependencyElement).isEqualTo(dependencyElement);
+        assertThat(fixedDependencyElement.getLicenses()).hasSize(1);
+
+        Collection<LicenseElement> fixedLicenseElements = fixedDependencyElement.getLicenses();
+        assertThat(fixedLicenseElements).containsOnly(
+                new LicenseElement("Test License Name 3", "http://test-license-3.com/licens.html", "http://internal-host/license3.txt"));
+
+        verify(mockLicenseSanitiser, times(0)).fix(any());
     }
 
 }

--- a/src/test/resources/rh-license-names.json
+++ b/src/test/resources/rh-license-names.json
@@ -18,5 +18,16 @@
     "urlAliases": [
       "http://test-license-alias-2.com"
     ]
+  },
+  {
+    "name": "Test License Name 3",
+    "url": "http://test-license-3.com/licens.html",
+    "textUrl": "http://internal-host/license3.txt",
+    "aliases": [
+      "Test License Name 3"
+    ],
+    "urlAliases": [
+      "http://test-license-3.com/licens.html"
+    ]
   }
 ]


### PR DESCRIPTION
Currently, Licenses Generator ignores dependencies for which MavenProject cannot be created.
This change makes Generator process these dependencies, in hope to find the licenses in the external service.
Moreover, the generator after changes will fail if it is unable to find a license for some artifact. It is motivated by the fact that we need to have licenses for all artifacts.

Additionally, time-outs for downloading licenses have been added, plus a textUrl field in the rh-license-names file.