### PR TITLE
Sanitise common alias url prefixes

### DIFF
--- a/src/main/java/me/snowdrop/licenses/sanitiser/AliasLicenseSanitiser.java
+++ b/src/main/java/me/snowdrop/licenses/sanitiser/AliasLicenseSanitiser.java
@@ -16,11 +16,11 @@
 
 package me.snowdrop.licenses.sanitiser;
 
-import me.snowdrop.licenses.xml.DependencyElement;
-import me.snowdrop.licenses.xml.LicenseElement;
-
 import java.util.Optional;
 import java.util.Set;
+
+import me.snowdrop.licenses.xml.DependencyElement;
+import me.snowdrop.licenses.xml.LicenseElement;
 
 import static me.snowdrop.licenses.utils.JsonUtils.loadJsonToSet;
 
@@ -44,10 +44,10 @@ public class AliasLicenseSanitiser implements LicenseSanitiser {
         DependencyElement dependencyElement = new DependencyElement(originalDependencyElement);
 
         for (LicenseElement licenseElement : dependencyElement.getLicenses()) {
-            Optional<RedHatLicense> redHatLicenseOptional = getRedHatLicenseByUrl(licenseElement.getUrl());
-            if (!redHatLicenseOptional.isPresent()) {
-                redHatLicenseOptional = getRedHatLicenseByName(licenseElement.getName());
-            }
+            Optional<RedHatLicense> redHatLicenseOptional = redHatLicenses.stream()
+                    .filter(redHatLicense -> redHatLicense.isAliasTo(licenseElement))
+                    .findFirst();
+
             if (redHatLicenseOptional.isPresent()) {
                 RedHatLicense redHatLicense = redHatLicenseOptional.get();
                 licenseElement.setName(redHatLicense.getName());
@@ -63,26 +63,6 @@ public class AliasLicenseSanitiser implements LicenseSanitiser {
         }
 
         return dependencyElement;
-    }
-
-    private Optional<RedHatLicense> getRedHatLicenseByUrl(String url) {
-        if (url == null) {
-            return Optional.empty();
-        }
-        return redHatLicenses.stream()
-                .filter(l -> l.getUrlAliases()
-                        .contains(url.toLowerCase()))
-                .findFirst();
-    }
-
-    private Optional<RedHatLicense> getRedHatLicenseByName(String name) {
-        if (name == null) {
-            return Optional.empty();
-        }
-        return redHatLicenses.stream()
-                .filter(l -> l.getAliases()
-                        .contains(name.toLowerCase()))
-                .findFirst();
     }
 
 }

--- a/src/test/java/me/snowdrop/licenses/sanitiser/RedHatLicenseTest.java
+++ b/src/test/java/me/snowdrop/licenses/sanitiser/RedHatLicenseTest.java
@@ -1,0 +1,85 @@
+package me.snowdrop.licenses.sanitiser;
+
+import java.util.Arrays;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+
+import me.snowdrop.licenses.xml.LicenseElement;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RedHatLicenseTest {
+
+    private static JsonObject LICENSE_WITH_ALIASES = Json.createObjectBuilder()
+            .add("name", "Apache License 2.0")
+            .add("url", "http://www.apache.org/licenses/LICENSE-2.0")
+            .add("textUrl", "http://www.apache.org/licenses/LICENSE-2.0.txt")
+            .add("aliases", Json.createArrayBuilder(Arrays.asList("Apache License", "   ASL 2.0   ")))
+            .add("urlAliases", Json.createArrayBuilder(Arrays.asList(
+                    "http://www.apache.org/licenses/LICENSE-2.0/",
+                    "https://apache.org/licenses/LICENSE-2.0",
+                    "www.apache.org/licenses/LICENSE-2.0.txt    "
+            )))
+            .build();
+
+    private static JsonObject LICENSE_WITHOUT_ALIASES = Json.createObjectBuilder()
+            .add("name", "MIT License")
+            .add("url", "https://opensource.org/licenses/MIT")
+            .build();
+
+    @Test
+    public void shouldLoadSanitisedData() {
+        RedHatLicense redHatLicense = new RedHatLicense(LICENSE_WITH_ALIASES);
+        assertThat(redHatLicense.getName()).isEqualTo("Apache License 2.0");
+        assertThat(redHatLicense.getUrl()).isEqualTo("http://www.apache.org/licenses/LICENSE-2.0");
+        assertThat(redHatLicense.getTextUrl()).isEqualTo("http://www.apache.org/licenses/LICENSE-2.0.txt");
+        assertThat(redHatLicense.getAliases()).containsOnly("apache license", "asl 2.0");
+        assertThat(redHatLicense.getUrlAliases()).containsOnly(
+                "apache.org/licenses/license-2.0",
+                "apache.org/licenses/license-2.0.txt"
+        );
+
+        redHatLicense = new RedHatLicense(LICENSE_WITHOUT_ALIASES);
+        assertThat(redHatLicense.getName()).isEqualTo("MIT License");
+        assertThat(redHatLicense.getUrl()).isEqualTo("https://opensource.org/licenses/MIT");
+        assertThat(redHatLicense.getTextUrl()).isEqualTo("https://opensource.org/licenses/MIT");
+        assertThat(redHatLicense.getAliases()).isEmpty();
+        assertThat(redHatLicense.getUrlAliases()).isEmpty();
+    }
+
+    @Test
+    public void shouldGetLicenseElement() {
+        RedHatLicense redHatLicense = new RedHatLicense(LICENSE_WITH_ALIASES);
+        LicenseElement licenseElement = redHatLicense.toLicenseElement();
+
+        assertThat(licenseElement.getName()).isEqualTo("Apache License 2.0");
+        assertThat(licenseElement.getUrl()).isEqualTo("http://www.apache.org/licenses/LICENSE-2.0");
+        assertThat(licenseElement.getTextUrl()).isEqualTo("http://www.apache.org/licenses/LICENSE-2.0.txt");
+    }
+
+    @Test
+    public void shouldRecogniseNameAlias() {
+        RedHatLicense redHatLicense = new RedHatLicense(LICENSE_WITH_ALIASES);
+        LicenseElement licenseElement = new LicenseElement("APACHE LICENSE", "example.com");
+
+        assertThat(redHatLicense.isAliasTo(licenseElement)).isTrue();
+    }
+
+    @Test
+    public void shouldRecogniseUrlAlias() {
+        RedHatLicense redHatLicense = new RedHatLicense(LICENSE_WITH_ALIASES);
+        LicenseElement licenseElement = new LicenseElement("Example", "https://apache.org/licenses/LICENSE-2.0/");
+
+        assertThat(redHatLicense.isAliasTo(licenseElement)).isTrue();
+    }
+
+    @Test
+    public void shouldNotRecognisedUnknownLicense() {
+        RedHatLicense redHatLicense = new RedHatLicense(LICENSE_WITH_ALIASES);
+        LicenseElement licenseElement = new LicenseElement("Example", "example.com");
+
+        assertThat(redHatLicense.isAliasTo(licenseElement)).isFalse();
+    }
+}


### PR DESCRIPTION
Update as discussed last week to remove http, https, www, and / from alias urls during the comparison.