### PR TITLE
Upgrade to the latest Maven core and resolver versions, target Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,10 +50,13 @@
     <commons-io.version>2.7</commons-io.version>
     <jaxb.version>2.3.1</jaxb.version>
     <json.version>1.1.4</json.version>
-    <jtwig.version>5.87.0.RELEASE</jtwig.version>
     <junit.version>4.12</junit.version>
+    <maven-core.version>3.9.6</maven-core.version>
     <maven-embedder.version>3.15</maven-embedder.version>
+    <maven-resolver.version>1.9.18</maven-resolver.version>
+    <maven-wagon.version>3.5.3</maven-wagon.version>
     <mockito.version>3.11.0</mockito.version>
+    <qute.version>2.16.12.Final</qute.version>
     <resteasy.version>4.5.12.Final</resteasy.version>
     <slf4j.version>1.7.30</slf4j.version>
     <undertow.version>2.2.8.Final</undertow.version>
@@ -100,17 +103,11 @@
   </repositories>
 
   <dependencies>
-    <!-- Twig -->
+    <!-- Qute -->
     <dependency>
-      <groupId>org.jtwig</groupId>
-      <artifactId>jtwig-core</artifactId>
-      <version>${jtwig.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>io.quarkus.qute</groupId>
+      <artifactId>qute-core</artifactId>
+      <version>${qute.version}</version>
     </dependency>
 
     <!-- JSON -->
@@ -130,17 +127,108 @@
           <groupId>javax.annotation</groupId>
           <artifactId>jsr250-api</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-artifact</artifactId>
+      <version>${maven-core.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-compat</artifactId>
+      <version>${maven-core.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>${maven-core.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.checkerframework</groupId>
+          <artifactId>checker-qual</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-embedder</artifactId>
+      <version>${maven-core.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <!-- let's prefer the plexus-utils pulled by maven-resolver-provider -->
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-utils</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.checkerframework</groupId>
+          <artifactId>checker-qual</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-connector-basic</artifactId>
+      <version>${maven-resolver.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-transport-wagon</artifactId>
+      <version>${maven-resolver.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-api</artifactId>
+      <version>${maven-resolver.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-spi</artifactId>
+      <version>${maven-resolver.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-impl</artifactId>
+      <version>${maven-resolver.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.resolver</groupId>
+      <artifactId>maven-resolver-util</artifactId>
+      <version>${maven-resolver.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-file</artifactId>
-      <version>3.3.2</version>
+      <version>${maven-wagon.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.wagon</groupId>
       <artifactId>wagon-http</artifactId>
-      <version>3.3.2</version>
+      <version>${maven-wagon.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -271,8 +359,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${maven-compiler-plugin.version}</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>11</source>
+          <target>11</target>
         </configuration>
       </plugin>
       <plugin>

--- a/src/main/resources/licenses.qute
+++ b/src/main/resources/licenses.qute
@@ -31,27 +31,27 @@
     <tr>
       <th>Package Group</th><th>Package Artifact</th><th>Package Version</th><th>Remote Licenses</th><th>Local Licenses</th>
     </tr>
-    {% for dependency in dependencies %}
+    {#for dependency in dependencies}
     <tr>
-      <td>{{ dependency.getGroupId() }}</td>
-      <td>{{ dependency.getArtifactId() }}</td>
-      <td>{{ dependency.getVersion() }}</td>
+      <td>{dependency.groupId}</td>
+      <td>{dependency.artifactId}</td>
+      <td>{dependency.version}</td>
       <td>
-        {% for license in dependency.getLicenses() %}
-        <a href="{{ license.getUrl() }}">{{ license.getName() }}</a>
+        {#for license in dependency.licenses}
+        <a href="{license.url}">{license.name}</a>
         <br/>
-        {% endfor %}
+        {/for}
       </td>
       <td>
-        {% for license in dependency.getLicenses() %}
-        {% if licenseFiles.containsKey(license.getName()) %}
-          <a href="{{ licenseFiles.get(license.getName()) }}">{{ license.getName() }}</a>
+        {#for license in dependency.licenses}
+        {#if licenseFiles.containsKey(license.name)}
+          <a href="{licenseFiles.get(license.name)}">{license.name}</a>
           <br/>
-        {% endif %}
-        {% endfor %}
+        {/if}
+        {/for}
       </td>
     </tr>
-    {% endfor %}
+    {/for}
   </table>
 </body>
 </html>


### PR DESCRIPTION
This change includes:
* upgrade of Maven core dependencies to 3.9.6
* upgrade of Maven resolver to 1.9.18
* Wagon to 3.5.3
* Replaces jtwig templating library with Qute (jtwig uses reflection calls on protected methods in classes from java.lang package which requires --all-opens option in later Java versions)
* targets Java 11
